### PR TITLE
DM-14557: Add package docs to datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/_build/

--- a/calib/defects.tar.gz
+++ b/calib/defects.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b26d39ccc1cfdb4b1b73a4435d8a54eca041a1094164c83739553ea28d3313a1
+size 2699

--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -1,3 +1,5 @@
 config.dataFiles = ['*.fits.gz']
 
+config.defectTarball = 'defects.tar.gz'
+
 config.refcats = {'gaia': 'gaia_example.tar.gz'}

--- a/doc/ap_verify_testdata/index.rst
+++ b/doc/ap_verify_testdata/index.rst
@@ -1,0 +1,35 @@
+.. _ap_verify_testdata-package:
+
+##################
+ap_verify_testdata
+##################
+
+The ``ap_verify_testdata`` package contains several files from `obs_test <https://github.com/lsst/obs_test/>`_.
+The package is intended to test dataset support in ``ap_verify`` code.
+
+Project info
+============
+
+Repository
+   https://github.com/lsst-dm/ap_verify_testdata
+
+.. Datasets do not have their own (or a collective) Jira components; by convention we include them in ap_verify
+
+Jira component
+   `ap_verify <https://jira.lsstcorp.org/issues/?jql=project %3D DM %20AND%20 component %3D ap_verify %20AND%20 text ~ "testdata">`_
+
+Dataset Contents
+================
+
+This package provides a number of demonstration files copied from `obs_test <https://github.com/lsst/obs_test/>`_.
+See that package for detailed file and provenance information.
+
+The dataset contents include raw images, biases, and flats.
+The dataset does not provide any image differencing templates.
+It does have a small Gaia DR1 reference catalog, but it is not guaranteed to overlap with the footprint of the raw data.
+
+Intended Use
+============
+
+This package provides a minimal valid dataset for testing dataset handling, particularly ingestion.
+Because there are no templates and the reference catalog is not guaranteed to match the data, this dataset is not suitable for full ``ap_verify`` runs.

--- a/doc/ap_verify_testdata/index.rst
+++ b/doc/ap_verify_testdata/index.rst
@@ -24,7 +24,7 @@ Dataset Contents
 This package provides a number of demonstration files copied from `obs_test <https://github.com/lsst/obs_test/>`_.
 See that package for detailed file and provenance information.
 
-The dataset contents include raw images, biases, and flats.
+The dataset contents include raw images, biases, flats, and defects.
 The dataset does not provide any image differencing templates.
 It does have a small Gaia DR1 reference catalog, but it is not guaranteed to overlap with the footprint of the raw data.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,12 @@
+"""Sphinx configuration file for an LSST stack package.
+
+This configuration only affects single-package Sphinx documenation builds.
+"""
+
+from documenteer.sphinxconfig.stackconf import build_package_configs
+
+
+_g = globals()
+_g.update(build_package_configs(
+    project_name='ap_verify_testdata',))
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,13 @@
+########################################
+ap_verify_testdata documentation preview
+########################################
+
+.. This page is for local development only. It isn't published to pipelines.lsst.io.
+
+.. Link the index pages of package and module documentation directions (listed in manifest.yaml).
+
+.. toctree::
+   :maxdepth: 1
+
+   ap_verify_testdata/index
+

--- a/doc/manifest.yaml
+++ b/doc/manifest.yaml
@@ -1,0 +1,16 @@
+# Documentation manifest.
+
+# Name of this package
+# Also the name of the package documentation subdirectory.
+package: "ap_verify_testdata"
+
+# List of names of Python modules in this package.
+# For each module there is a corresponding module doc subdirectory.
+# modules:
+#   - "lsst.ap.verify.testdata"
+
+# Name of the static content directories (subdirectories of `_static`).
+# Static content directories are usually named after the package.
+# statics:
+#   - "_static/ap_verify_testdata"
+


### PR DESCRIPTION
This PR adds documentation for the test dataset (although it is not linked to from anywhere, as this dataset was not meant to be user-visible).